### PR TITLE
New option 'plain_score' for ExplainRenderer

### DIFF
--- a/lib/elasticsearch/api/response/explain_renderer.rb
+++ b/lib/elasticsearch/api/response/explain_renderer.rb
@@ -9,6 +9,7 @@ module Elasticsearch
         def initialize(options = {})
           disable_colorization if options[:colorize] == false
           @max = options[:max] || 3
+          @plain_score = options[:plain_score] == true
         end
 
         def render(tree)
@@ -36,7 +37,7 @@ module Elasticsearch
         end
 
         def render_score(score)
-          value = if score > 1_000
+          value = if !@plain_score && score > 1_000
             sprintf("%1.2g", score.round(2))
           else
             score.round(2).to_s

--- a/lib/elasticsearch/api/response/explain_response.rb
+++ b/lib/elasticsearch/api/response/explain_response.rb
@@ -19,8 +19,8 @@ module Elasticsearch
           # Show scoring as a simple math formula
           # @example
           #    "1.0 = (1.0(termFreq=1.0)) x 1.0(idf(2/3)) x 1.0(fieldNorm)"
-          def render_in_line(result, max: nil)
-            new(result["explanation"], max: max).render_in_line
+          def render_in_line(result, options = {})
+            new(result["explanation"], options).render_in_line
           end
 
           # Show scoring with indents
@@ -30,17 +30,17 @@ module Elasticsearch
           #       3.35 = 0.2 + 0.93 + 1.29 + 0.93
           #     54.3 = 54.3 min 3.4028234999999995e+38(maxBoost)
           #       54.3 = 2.0 x 10.0 x 3.0 x 0.91
-          def render(result, max: nil)
-            new(result["explanation"], max: max).render
+          def render(result, options = {})
+            new(result["explanation"], options).render
           end
         end
 
         attr_reader :explain
 
-        def initialize(explain, max: nil, colorize: true)
+        def initialize(explain, options = {})
           @explain = explain
           @indent = 0
-          @renderer = ExplainRenderer.new(max: max, colorize: colorize)
+          @renderer = ExplainRenderer.new({ colorize: true }.merge(options))
         end
 
         def render

--- a/spec/elasticsearch/api/response/explain_response_spec.rb
+++ b/spec/elasticsearch/api/response/explain_response_spec.rb
@@ -52,10 +52,11 @@ describe Elasticsearch::API::Response::ExplainResponse do
 
   describe "#render" do
     let(:response) do
-      described_class.new(fake_response["explanation"], max: max, colorize: false)
+      described_class.new(fake_response["explanation"], max: max, colorize: false, plain_score: plain_score)
     end
 
     let(:max) { nil }
+    let(:plain_score) { nil }
 
     subject do
       response.render.lines.map(&:rstrip)
@@ -84,6 +85,19 @@ describe Elasticsearch::API::Response::ExplainResponse do
           "          0.25 = 1.0(tf(1.0)) x 1.0(idf(2/3)) x 0.25(fieldNorm(doc=0))",
           "          10.0 = 10.0 x 1.0(match(name.raw:smith))",
           "          0.99 = 0.99(func(updated_at))"
+        ])
+      end
+    end
+
+    context "with plain_score = true" do
+      let(:plain_score) { true }
+
+      it "returns summary of explain in lines" do
+        expect(subject).to match_array([
+          "0.05 = 0.11 x 0.5(coord(1/2)) x 1.0(queryBoost)",
+          "  0.11 = 0.11 min 3.4028235e+38",
+          "    0.11 = 0.11(weight(_all:smith))",
+          "      0.11 = 0.11(score)"
         ])
       end
     end


### PR DESCRIPTION
For some cases it is important to see the correct score value, so I added a new option called `plain_score` to see to real score.
### plain_score = false

```
0.05 = 0.11 x 0.5(coord(1/2)) x 1.0(queryBoost)
  0.11 = 0.11 min 4.5e+11
    0.11 = 0.11(weight(_all:smith))
      0.11 = 0.11(score)
```
### plain_score = true

```
0.05 = 0.11 x 0.5(coord(1/2)) x 1.0(queryBoost)
  0.11 = 0.11 min 454655156657.0
    0.11 = 0.11(weight(_all:smith))
      0.11 = 0.11(score)
```
