### PR TITLE
Add support for script score

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ bundle
 ```
 
 Or install it yourself as:
-    
+
 ```
 $ gem install elasticsearch-explain-response
 ```
@@ -55,7 +55,7 @@ puts Elasticsearch::API::Response::ExplainResponse.new(result["explanation"]).re
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/elasticsearch-explain-response/fork )
+1. Fork it ( https://github.com/tomoya55/elasticsearch-explain-response/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/elasticsearch/api/response/explain_parser.rb
+++ b/lib/elasticsearch/api/response/explain_parser.rb
@@ -1,7 +1,11 @@
+require "elasticsearch/api/response/string_helper"
+
 module Elasticsearch
   module API
     module Response
       class ExplainParser
+        include StringHelper
+
         def parse(explain_tree)
           root = create_node(explain_tree, level: 0)
           parse_details(root)
@@ -45,12 +49,14 @@ module Elasticsearch
             type =  "score"
             operation = "score"
             operator = "x"
-          when /\Amatch filter\: (?:cache\()?(?:(?<op>[\w]+)\()*(?<f>.+)\:(?<v>[^\)]+)\)*\z/
+          when /\Amatch filter\: (?:cache\()?(?:(?<op>[\w]+)\()*(?<c>.+)\)*\z/
             type = "match"
             operation = "match"
             operation += ".#{$~[:op]}" if $~[:op] && !%w[QueryWrapperFilter].include?($~[:op])
-            field = $~[:f]
-            value = $~[:v]
+            content = $~[:c]
+            hash = tokenize_contents(content)
+            field = hash.keys.join(", ")
+            value = hash.values.join(", ")
           when /\AFunction for field ([\w\_]+)\:\z/
             type = "func"
             operation = "func"
@@ -70,6 +76,15 @@ module Elasticsearch
             /\Afunction score\, score mode \[multiply\]\z/
             type = "func score"
             operator = "x"
+          when /\Ascript score function\, computed with script:\"(?<s>.+)\"\s*(?:and parameters:\s*(?<p>.+))?/m
+            type = "script"
+            operation = "script"
+            script, param = $~[:s], $~[:p]
+            script = script.gsub("\n", '')
+            script = "\"#{script}\""
+            param.gsub!("\n", '') if param
+            field = script.scan(/doc\[\'([\w\.]+)\'\]/).flatten.uniq.compact.join(" ")
+            value = [script, param].join(" ")
           when "static boost factor", "boostFactor"
             type = "boost"
             operation = "boost"
@@ -92,8 +107,6 @@ module Elasticsearch
             type = description
             operation = description
           end
-
-          # binding.pry if operator.nil?
 
           Description.new(
             raw: description,

--- a/lib/elasticsearch/api/response/explain_parser.rb
+++ b/lib/elasticsearch/api/response/explain_parser.rb
@@ -54,6 +54,7 @@ module Elasticsearch
             operation = "match"
             operation += ".#{$~[:op]}" if $~[:op] && !%w[QueryWrapperFilter].include?($~[:op])
             content = $~[:c]
+            content = content[0..-2] if content.end_with?(')')
             hash = tokenize_contents(content)
             field = hash.keys.join(", ")
             value = hash.values.join(", ")

--- a/lib/elasticsearch/api/response/explain_renderer.rb
+++ b/lib/elasticsearch/api/response/explain_renderer.rb
@@ -10,6 +10,7 @@ module Elasticsearch
           disable_colorization if options[:colorize] == false
           @max = options[:max] || 3
           @plain_score = options[:plain_score] == true
+          @show_values = options[:show_values] == true
         end
 
         def render(tree)
@@ -108,7 +109,11 @@ module Elasticsearch
           text = ''
           text = description.operation if description.operation
           if description.field && description.value
-            text += "(#{field(description.field)}:#{value(description.value)})"
+            if @show_values
+              text += "(#{field(description.field)}:#{value(description.value)})"
+            else
+              text += "(#{field(description.field)})"
+            end
           elsif description.field
             text += "(#{field(description.field)})"
           end

--- a/lib/elasticsearch/api/response/string_helper.rb
+++ b/lib/elasticsearch/api/response/string_helper.rb
@@ -1,0 +1,21 @@
+module Elasticsearch
+  module API
+    module Response
+      module StringHelper
+        WORD = /[\w\.\*]+/
+        WITH_QUOTE = /"[^"]*"/
+        WITH_BRACKET = /\[[^\]]*\]/
+        QUOTE_TOKENIZER = /(?:(?<field>#{WORD})(\:(?<value>(#{WORD}|#{WITH_QUOTE}|#{WITH_BRACKET})))?)+/
+
+        # @return [Hash] field name as a key and values as a value
+        def tokenize_contents(string)
+          string
+            .scan(QUOTE_TOKENIZER)
+            .each_with_object(Hash.new{|h,k| h[k] = []}) { |(field, value), memo|
+              memo[field] << value
+            }
+        end
+      end
+    end
+  end
+end

--- a/spec/elasticsearch/api/response/explain_response_spec.rb
+++ b/spec/elasticsearch/api/response/explain_response_spec.rb
@@ -28,7 +28,7 @@ describe Elasticsearch::API::Response::ExplainResponse do
 
   describe "#render_in_line" do
     let(:response) do
-      described_class.new(fake_response["explanation"], colorize: false, max: 4, show_values: show_values)
+      described_class.new(fake_response["explanation"], colorize: false, max: 5, show_values: show_values)
     end
 
     subject do
@@ -41,7 +41,7 @@ describe Elasticsearch::API::Response::ExplainResponse do
       end
 
       it "returns summary of explain in line" do
-        expect(subject).to eq("0.05 = ((0.43(queryWeight) x 0.25(fieldWeight) x 10.0 x 0.99 x 5.93(script(popularity:\"def val = factor * log(sqrt(doc['popularity'].value) + 1) + 1\" {factor=1.0}))) min 3.4e+38) x 0.5(coord(1/2)) x 1.0(queryBoost)")
+        expect(subject).to eq("0.05 = ((1.0(idf(2/3)) x 0.43(queryNorm)) x (1.0(tf(1.0)) x 1.0(idf(2/3)) x 0.25(fieldNorm(doc=0))) x 10.0(match(name.raw:smith)) x 0.99(func(updated_at)) x 5.93(script(popularity:\"def val = factor * log(sqrt(doc['popularity'].value) + 1) + 1\" {factor=1.0})) min 3.4e+38) x 0.5(coord(1/2)) x 1.0(queryBoost)")
       end
 
       context "with fake_response2" do
@@ -51,6 +51,26 @@ describe Elasticsearch::API::Response::ExplainResponse do
 
         it "returns summary of explain in line" do
           expect(subject).to eq("887.19 = ((10.0(match(name:hawaii)) x 10.0(match(name:guam)) x 0.7(match(name:\"new caledonia\", new, nueva, caledonia)) x 3.0(match(with_beach:T)) x 0.99(func(updated_at)) x 3.0(match(region_id:[3 TO 3]))) min 3.4e+38) x 1.0(queryBoost)")
+        end
+      end
+    end
+
+    context "with show_values false" do
+      let(:show_values) do
+        false
+      end
+
+      it "returns summary of explain in line" do
+        expect(subject).to eq("0.05 = ((1.0(idf(2/3)) x 0.43(queryNorm)) x (1.0(tf(1.0)) x 1.0(idf(2/3)) x 0.25(fieldNorm(doc=0))) x 10.0(match(name.raw)) x 0.99(func(updated_at)) x 5.93(script(popularity)) min 3.4e+38) x 0.5(coord(1/2)) x 1.0(queryBoost)")
+      end
+
+      context "with fake_response2" do
+        let(:fake_response) do
+          fixture_load(:response2)
+        end
+
+        it "returns summary of explain in line" do
+          expect(subject).to eq("887.19 = ((10.0(match(name)) x 10.0(match(name)) x 0.7(match(name)) x 3.0(match(with_beach)) x 0.99(func(updated_at)) x 3.0(match(region_id))) min 3.4e+38) x 1.0(queryBoost)")
         end
       end
     end

--- a/spec/elasticsearch/api/response/explain_response_spec.rb
+++ b/spec/elasticsearch/api/response/explain_response_spec.rb
@@ -28,77 +28,88 @@ describe Elasticsearch::API::Response::ExplainResponse do
 
   describe "#render_in_line" do
     let(:response) do
-      described_class.new(fake_response["explanation"], colorize: false, max: 4)
+      described_class.new(fake_response["explanation"], colorize: false, max: 4, show_values: show_values)
     end
 
     subject do
       response.render_in_line
     end
 
-    it "returns summary of explain in line" do
-      expect(subject).to eq("0.05 = ((0.43(queryWeight) x 0.25(fieldWeight) x 10.0 x 0.99) min 3.4e+38) x 0.5(coord(1/2)) x 1.0(queryBoost)")
-    end
-
-    context "with fake_response2" do
-      let(:fake_response) do
-        fixture_load(:response2)
+    context "with show_values" do
+      let(:show_values) do
+        true
       end
 
       it "returns summary of explain in line" do
-        expect(subject).to eq("887.19 = ((10.0(match(name:hawaii)) x 10.0(match(name:guam)) x 0.7(match(name:\"new caledonia\" (+(name:new name:nueva) +name:caledonia)) x 3.0(match(with_beach:T)) x 0.99(func(updated_at)) x 3.0(match(region_id:[3 TO 3]))) min 3.4e+38) x 1.0(queryBoost)")
+        expect(subject).to eq("0.05 = ((0.43(queryWeight) x 0.25(fieldWeight) x 10.0 x 0.99 x 5.93(script(popularity:\"def val = factor * log(sqrt(doc['popularity'].value) + 1) + 1\" {factor=1.0}))) min 3.4e+38) x 0.5(coord(1/2)) x 1.0(queryBoost)")
+      end
+
+      context "with fake_response2" do
+        let(:fake_response) do
+          fixture_load(:response2)
+        end
+
+        it "returns summary of explain in line" do
+          expect(subject).to eq("887.19 = ((10.0(match(name:hawaii)) x 10.0(match(name:guam)) x 0.7(match(name:\"new caledonia\", new, nueva, caledonia)) x 3.0(match(with_beach:T)) x 0.99(func(updated_at)) x 3.0(match(region_id:[3 TO 3]))) min 3.4e+38) x 1.0(queryBoost)")
+        end
       end
     end
   end
 
   describe "#render" do
     let(:response) do
-      described_class.new(fake_response["explanation"], max: max, colorize: false, plain_score: plain_score)
+      described_class.new(fake_response["explanation"], max: max, colorize: false, plain_score: plain_score, show_values: show_values)
     end
 
     let(:max) { nil }
     let(:plain_score) { nil }
+    let(:show_values) { false }
 
     subject do
       response.render.lines.map(&:rstrip)
     end
 
-    it "returns summary of explain in lines" do
-      expect(subject).to match_array [
-        "0.05 = 0.11 x 0.5(coord(1/2)) x 1.0(queryBoost)",
-        "  0.11 = 0.11 min 3.4e+38",
-        "    0.11 = 0.11(weight(_all:smith))",
-        "      0.11 = 0.11(score)"
-      ]
-    end
-
-    context "with max = 5" do
-      let(:max) { 5 }
+    context "with show_values" do
+      let(:show_values) { true }
 
       it "returns summary of explain in lines" do
-        expect(subject).to match_array([
+        expect(subject).to match_array [
           "0.05 = 0.11 x 0.5(coord(1/2)) x 1.0(queryBoost)",
           "  0.11 = 0.11 min 3.4e+38",
           "    0.11 = 0.11(weight(_all:smith))",
-          "      0.11 = 0.11(score)",
-          "        0.11 = 0.43(queryWeight) x 0.25(fieldWeight) x 10.0 x 0.99",
-          "          0.43 = 1.0(idf(2/3)) x 0.43(queryNorm)",
-          "          0.25 = 1.0(tf(1.0)) x 1.0(idf(2/3)) x 0.25(fieldNorm(doc=0))",
-          "          10.0 = 10.0 x 1.0(match(name.raw:smith))",
-          "          0.99 = 0.99(func(updated_at))"
-        ])
-      end
-    end
-
-    context "with plain_score = true" do
-      let(:plain_score) { true }
-
-      it "returns summary of explain in lines" do
-        expect(subject).to match_array([
-          "0.05 = 0.11 x 0.5(coord(1/2)) x 1.0(queryBoost)",
-          "  0.11 = 0.11 min 3.4028235e+38",
-          "    0.11 = 0.11(weight(_all:smith))",
           "      0.11 = 0.11(score)"
-        ])
+        ]
+      end
+
+      context "with max = 5" do
+        let(:max) { 5 }
+
+        it "returns summary of explain in lines" do
+          expect(subject).to match_array([
+            "0.05 = 0.11 x 0.5(coord(1/2)) x 1.0(queryBoost)",
+            "  0.11 = 0.11 min 3.4e+38",
+            "    0.11 = 0.11(weight(_all:smith))",
+            "      0.11 = 0.11(score)",
+            "        0.11 = 0.43(queryWeight) x 0.25(fieldWeight) x 10.0 x 0.99 x 5.93(script(popularity:\"def val = factor * log(sqrt(doc['popularity'].value) + 1) + 1\" {factor=1.0}))",
+            "          0.43 = 1.0(idf(2/3)) x 0.43(queryNorm)",
+            "          0.25 = 1.0(tf(1.0)) x 1.0(idf(2/3)) x 0.25(fieldNorm(doc=0))",
+            "          10.0 = 10.0 x 1.0(match(name.raw:smith))",
+            "          0.99 = 0.99(func(updated_at))"
+          ])
+        end
+      end
+
+      context "with plain_score = true" do
+        let(:plain_score) { true }
+
+        it "returns summary of explain in lines" do
+          expect(subject).to match_array([
+            "0.05 = 0.11 x 0.5(coord(1/2)) x 1.0(queryBoost)",
+            "  0.11 = 0.11 min 3.4028235e+38",
+            "    0.11 = 0.11(weight(_all:smith))",
+            "      0.11 = 0.11(score)"
+          ])
+        end
       end
     end
   end

--- a/spec/fixtures/response1.yml
+++ b/spec/fixtures/response1.yml
@@ -59,6 +59,10 @@ explanation:
               - value: 0.9857722
                 description: "exp(- MIN[Math.max(Math.abs(1.424917503E12(=doc value)\
                   \ - 1.432308964176E12(=origin))) - 0.0(=offset), 0)] * 1.938722193962471E-12)"
+          - value: 5.9284687
+            description: "script score function, computed with script:\"def val\
+              \ = factor * log(sqrt(doc['popularity'].value)\
+              \ + 1) + 1\" and parameters: \n{factor=1.0}"
     - value: 3.4028235E+38
       description: "maxBoost"
   - value: 0.5


### PR DESCRIPTION
- Add support for script score
- Add `show_values` option. If set to `false`, you can hide the script itself from explain result

``` ruby
puts Elasticsearch::API::Response::ExplainResponse.new(result["explanation"], show_values: false).render
0.05 = ((1.0(idf(2/3)) x 0.43(queryNorm)) x 
  (1.0(tf(1.0)) x 1.0(idf(2/3)) x 0.25(fieldNorm(doc=0))) x 
  10.0(match(name.raw)) x 0.99(func(updated_at)) x 
  5.93(script(popularity)) min 3.4e+38) x 
  0.5(coord(1/2)) x 1.0(queryBoost)
```
