### PR TITLE
Add ExplainFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,29 @@ puts Elasticsearch::API::Response::ExplainResponse.new(result["explanation"]).re
 ### Summarize the explanation in lines
 
 ```ruby
-require 'elasticsearch'
-client = Elasticsearch::Client.new
-result = client.explain index: "megacorp", type: "employee", id: "1", q: "last_name:Smith"
 puts Elasticsearch::API::Response::ExplainResponse.new(result["explanation"]).render
 #=>
 1.0 = 1.0(fieldWeight)
   1.0 = 1.0(tf(1.0)) x 1.0(idf(2/3)) x 1.0(fieldNorm)
     1.0 = 1.0(termFreq=1.0)
+```
+
+### Get the summarized explanation as a Hash
+
+```ruby
+puts Elasticsearch::API::Response::ExplainResponse.new(result["explanation"]).result
+#=>
+{ :score=>0.8467586,
+  :type=>"fieldWeight",
+  :operator=>"x",
+  :operation=>"fieldWeight",
+  :children=>
+   [{:score=>1.7320508,
+     :type=>"tf",
+     :operation=>"tf(3.0)",
+     :children=>[{:score=>3.0, :type=>"termFreq=3.0", :operation=>"termFreq=3.0"}]},
+    {:score=>4.469726, :type=>"idf", :operation=>"idf(382/12305)"},
+    {:score=>0.109375, :type=>"fieldNorm(doc=1035)", :operation=>"fieldNorm(doc=1035)"}]}
 ```
 
 ## Contributing

--- a/lib/elasticsearch/api/response/description.rb
+++ b/lib/elasticsearch/api/response/description.rb
@@ -12,6 +12,16 @@ module Elasticsearch
           @field = field
           @value = value
         end
+
+        def as_json
+          {
+            type: type,
+            operator: operator,
+            operation: operation,
+            field: field,
+            value: value
+          }.delete_if { |k, v| v.nil? }
+        end
       end
     end
   end

--- a/lib/elasticsearch/api/response/explain_formatter.rb
+++ b/lib/elasticsearch/api/response/explain_formatter.rb
@@ -1,0 +1,88 @@
+module Elasticsearch
+  module API
+    module Response
+      class ExplainFormatter
+        attr_reader :conditions
+
+        def initialize(options = {})
+          @conditions = [*options[:conditions]]
+        end
+
+        def format(tree)
+          recursive_format(tree)
+        end
+
+        def recursive_format(node)
+          format_node(node) if node.details.any?
+        end
+
+        private
+
+        def format_node(node)
+          case
+          when node.func_score?
+            format_func_score_node(node)
+          when node.min?
+            format_min_score_node(node)
+          when node.score_one?
+            nil
+          else
+            format_default_node(node)
+          end
+        end
+
+        def format_children(node, hash)
+          node.children.map(&method(:format_node)).compact.tap do |children|
+            remove_dup(children, hash)
+          end
+        end
+
+        def remove_dup(collection, target)
+          collection.delete_if {|elm| elm == target }
+        end
+
+        def format_default_node(node)
+          node.as_json.tap do |hash|
+            if node.has_children?
+              children = format_children(node, hash)
+              hash[:children] = children if children.any?
+            end
+          end
+        end
+
+        # @note simplify the func score function with match & boost
+        def format_func_score_node(node)
+          case node.children.size
+          when 2
+            match = node.children.find(&:match?)
+            boost = node.children.find(&:boost?)
+            if match && boost
+              return { score: node.score,
+                type:  node.type,
+                operation: node.operation,
+                field: node.children[0].field,
+                value: node.children[0].value,
+               }
+            end
+
+            boost = node.children.find do |n|
+              n.score_one? && (n.query_boost? || n.match?)
+            end
+            if boost
+              other = node.children.find { |e| e != boost }
+              return format_node(other)
+            end
+          end
+
+          format_default_node(node)
+        end
+
+        # @note show only the node with a minimum score
+        def format_min_score_node(node)
+          child = node.children.find {|n| n.score == node.score }
+          format_node(child)
+        end
+      end
+    end
+  end
+end

--- a/lib/elasticsearch/api/response/explain_node.rb
+++ b/lib/elasticsearch/api/response/explain_node.rb
@@ -2,8 +2,12 @@ module Elasticsearch
   module API
     module Response
       class ExplainNode
+        extend Forwardable
+
         attr_reader :score, :description, :details, :level
         attr_accessor :children
+
+        def_delegators :@description, :type, :operator, :operation, :field, :value
 
         def initialize(score:, description:, details: [], level: 0)
           @score = score
@@ -13,12 +17,12 @@ module Elasticsearch
           @children = []
         end
 
-        def operator
-          description.operator
+        def score_one?
+          score == 1.0
         end
 
-        def type
-          description.type
+        def min?
+          type == "min"
         end
 
         def func?
@@ -30,7 +34,7 @@ module Elasticsearch
         end
 
         def match_all?
-          type == "match" && description.field == "*" && description.value == "*"
+          type == "match" && field == "*" && value == "*"
         end
 
         def boost?
@@ -39,6 +43,26 @@ module Elasticsearch
 
         def max_boost?
           type == "maxBoost"
+        end
+
+        def func_score?
+          type == "func score"
+        end
+
+        def query_boost?
+          type == "queryBoost"
+        end
+
+        def script?
+          type == "script"
+        end
+
+        def has_children?
+          children.any?
+        end
+
+        def as_json
+          { score: score }.merge(description.as_json)
         end
       end
     end

--- a/lib/elasticsearch/api/response/explain_response.rb
+++ b/lib/elasticsearch/api/response/explain_response.rb
@@ -2,6 +2,7 @@ require "elasticsearch/api/response/explain_node"
 require "elasticsearch/api/response/description"
 require "elasticsearch/api/response/explain_parser"
 require "elasticsearch/api/response/explain_renderer"
+require "elasticsearch/api/response/explain_formatter"
 
 module Elasticsearch
   module API
@@ -19,8 +20,8 @@ module Elasticsearch
           # Show scoring as a simple math formula
           # @example
           #    "1.0 = (1.0(termFreq=1.0)) x 1.0(idf(2/3)) x 1.0(fieldNorm)"
-          def render_in_line(result, options = {})
-            new(result["explanation"], options).render_in_line
+          def render_in_line(response, options = {})
+            new(response["explanation"], options).render_in_line
           end
 
           # Show scoring with indents
@@ -30,8 +31,13 @@ module Elasticsearch
           #       3.35 = 0.2 + 0.93 + 1.29 + 0.93
           #     54.3 = 54.3 min 3.4028234999999995e+38(maxBoost)
           #       54.3 = 2.0 x 10.0 x 3.0 x 0.91
-          def render(result, options = {})
-            new(result["explanation"], options).render
+          def render(response, options = {})
+            new(response["explanation"], options).render
+          end
+
+          # Return parsed result in Hash
+          def result(response, options = {})
+            new(response["explanation"], options).result
           end
         end
 
@@ -51,6 +57,11 @@ module Elasticsearch
         def render_in_line
           parse_details
           @renderer.render_in_line(@root)
+        end
+
+        def result(options = {})
+          parse_details
+          ExplainFormatter.new(options).format(@root)
         end
 
         private


### PR DESCRIPTION
- `ExplainResponse#result` returns the summarlized explain object from ruby program
  - Internally `ExplainFormatter` is defined to go through the parsed explain object and remove redundant information

```
puts Elasticsearch::API::Response::ExplainResponse.new(result["explanation"]).result
#=>
{ :score=>0.8467586,
  :type=>"fieldWeight",
  :operator=>"x",
  :operation=>"fieldWeight",
  :children=>
   [{:score=>1.7320508,
     :type=>"tf",
     :operation=>"tf(3.0)",
     :children=>[{:score=>3.0, :type=>"termFreq=3.0", :operation=>"termFreq=3.0"}]},
    {:score=>4.469726, :type=>"idf", :operation=>"idf(382/12305)"},
    {:score=>0.109375, :type=>"fieldNorm(doc=1035)", :operation=>"fieldNorm(doc=1035)"}]}
```
