### PR TITLE
Hash renderer

### DIFF
--- a/elasticsearch-explain-response.gemspec
+++ b/elasticsearch-explain-response.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "elasticsearch-explain-response"
-  spec.version       = "0.1.0"
+  spec.version       = "0.1.1"
   spec.authors       = ["Tomoya Hirano"]
   spec.email         = ["hiranotomoya@gmail.com"]
   spec.summary       = %q{Parser for Elasticserach Explain response}
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~>3.2"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "elasticsearch", "~> 1.0.0"
-  spec.add_development_dependency "ansi", "~> 1.5.0"
+  spec.add_development_dependency "ansi"
 end

--- a/lib/elasticsearch/api/response/description.rb
+++ b/lib/elasticsearch/api/response/description.rb
@@ -12,6 +12,16 @@ module Elasticsearch
           @field = field
           @value = value
         end
+
+        def as_json
+          {
+            type: type,
+            operator: operator,
+            operation: operation,
+            field: field,
+            value: value
+          }.delete_if { |k, v| v.nil? }
+        end
       end
     end
   end

--- a/lib/elasticsearch/api/response/explain_node.rb
+++ b/lib/elasticsearch/api/response/explain_node.rb
@@ -2,8 +2,12 @@ module Elasticsearch
   module API
     module Response
       class ExplainNode
+        extend Forwardable
+
         attr_reader :score, :description, :details, :level
         attr_accessor :children
+
+        def_delegators :@description, :type, :operator, :operation, :field, :value
 
         def initialize(score:, description:, details: [], level: 0)
           @score = score
@@ -13,12 +17,12 @@ module Elasticsearch
           @children = []
         end
 
-        def operator
-          description.operator
+        def score_one?
+          score == 1.0
         end
 
-        def type
-          description.type
+        def min?
+          type == "min"
         end
 
         def func?
@@ -30,7 +34,7 @@ module Elasticsearch
         end
 
         def match_all?
-          type == "match" && description.field == "*" && description.value == "*"
+          type == "match" && field == "*" && value == "*"
         end
 
         def boost?
@@ -39,6 +43,26 @@ module Elasticsearch
 
         def max_boost?
           type == "maxBoost"
+        end
+
+        def func_score?
+          type == "func score"
+        end
+
+        def query_boost?
+          type == "queryBoost"
+        end
+
+        def script?
+          type == "script"
+        end
+
+        def has_children?
+          children.any?
+        end
+
+        def as_json
+          { score: score }.merge(description.as_json)
         end
       end
     end

--- a/lib/elasticsearch/api/response/explain_response.rb
+++ b/lib/elasticsearch/api/response/explain_response.rb
@@ -1,3 +1,4 @@
+require "elasticsearch/api/response/renderers/hash_renderer"
 require "elasticsearch/api/response/explain_node"
 require "elasticsearch/api/response/description"
 require "elasticsearch/api/response/explain_parser"
@@ -51,6 +52,11 @@ module Elasticsearch
         def render_in_line
           parse_details
           @renderer.render_in_line(@root)
+        end
+
+        def render_as_hash
+          parse_details
+          Renderers::HashRenderer.new.render(@root)
         end
 
         private

--- a/lib/elasticsearch/api/response/renderers/hash_renderer.rb
+++ b/lib/elasticsearch/api/response/renderers/hash_renderer.rb
@@ -1,0 +1,41 @@
+module Elasticsearch
+  module API
+    module Response
+      module Renderers
+        class HashRenderer
+          def initialize
+          end
+
+          def render(tree)
+            recursive_render(tree)
+          end
+
+          def recursive_render(node)
+            format_node(node) if node.details.any?
+          end
+
+          private
+
+          def format_node(node)
+            node.as_json.tap do |hash|
+              if node.has_children?
+                children = format_children(node, hash)
+                hash[:children] = children if children.any?
+              end
+            end
+          end
+
+          def format_children(node, hash)
+            node.children.map(&method(:format_node)).compact.tap do |children|
+              remove_dup(children, hash)
+            end
+          end
+
+          def remove_dup(collection, target)
+            collection.delete_if {|elm| elm == target }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/elasticsearch/api/response/explain_response_spec.rb
+++ b/spec/elasticsearch/api/response/explain_response_spec.rb
@@ -134,6 +134,20 @@ describe Elasticsearch::API::Response::ExplainResponse do
     end
   end
 
+  describe "#render_as_hash" do
+    let(:response) do
+      described_class.new(fake_response["explanation"], colorize: false)
+    end
+
+    subject do
+      response.render_as_hash
+    end
+
+    it "returns the explain response as a hash" do
+      expect(subject).to be_a_kind_of(Hash)
+    end
+  end
+
   describe "colorization" do
     let(:response) do
       described_class.new(fake_response["explanation"])


### PR DESCRIPTION
### Overview

`HashRenderer` returns the parsed explain response as a Ruby hash. It is intended to be used in main Ruby application.
