### PR TITLE
Make ExplainNode Renderable

### DIFF
--- a/lib/elasticsearch/api/response/explain_node.rb
+++ b/lib/elasticsearch/api/response/explain_node.rb
@@ -1,7 +1,10 @@
+require "elasticsearch/api/response/renderable"
+
 module Elasticsearch
   module API
     module Response
       class ExplainNode
+        include Renderable
         extend Forwardable
 
         attr_reader :score, :description, :details, :level

--- a/lib/elasticsearch/api/response/explain_response.rb
+++ b/lib/elasticsearch/api/response/explain_response.rb
@@ -22,8 +22,8 @@ module Elasticsearch
           # Show scoring as a simple math formula
           # @example
           #    "1.0 = (1.0(termFreq=1.0)) x 1.0(idf(2/3)) x 1.0(fieldNorm)"
-          def render_in_line(result, options = {})
-            new(result["explanation"], options).render_in_line
+          def render_in_line(result, options = {}, &block)
+            new(result["explanation"], options).render_in_line(&block)
           end
 
           # Show scoring with indents
@@ -33,8 +33,8 @@ module Elasticsearch
           #       3.35 = 0.2 + 0.93 + 1.29 + 0.93
           #     54.3 = 54.3 min 3.4028234999999995e+38(maxBoost)
           #       54.3 = 2.0 x 10.0 x 3.0 x 0.91
-          def render(result, options = {})
-            new(result["explanation"], options).render
+          def render(result, options = {}, &block)
+            new(result["explanation"], options).render(&block)
           end
 
           def result_as_hash(result, options = {})
@@ -53,16 +53,16 @@ module Elasticsearch
           parse_details
         end
 
-        def render
-          Renderers::StandardRenderer.new({ colorize: true }.merge(rendering_options)).render(@root)
+        def render(&block)
+          @root.render(rendering_options, &block)
         end
 
-        def render_in_line
-          Renderers::InlineRenderer.new({ colorize: true }.merge(rendering_options)).render(@root)
+        def render_in_line(&block)
+          @root.render_in_line(rendering_options, &block)
         end
 
-        def render_as_hash
-          Renderers::HashRenderer.new.render(@root)
+        def render_as_hash(&block)
+          @root.render_as_hash(rendering_options, &block)
         end
 
         private

--- a/lib/elasticsearch/api/response/renderable.rb
+++ b/lib/elasticsearch/api/response/renderable.rb
@@ -1,0 +1,22 @@
+module Elasticsearch
+  module API
+    module Response
+      module Renderable
+        def render(rendering_options = {})
+          tree = block_given? ? yield(self) : self
+          Renderers::StandardRenderer.new({ colorize: true }.merge(rendering_options)).render(tree)
+        end
+
+        def render_in_line(rendering_options = {})
+          tree = block_given? ? yield(self) : self
+          Renderers::InlineRenderer.new({ colorize: true }.merge(rendering_options)).render(tree)
+        end
+
+        def render_as_hash(rendering_options = {})
+          tree = block_given? ? yield(self) : self
+          Renderers::HashRenderer.new.render(tree)
+        end
+      end
+    end
+  end
+end

--- a/spec/elasticsearch/api/response/explain_response_spec.rb
+++ b/spec/elasticsearch/api/response/explain_response_spec.rb
@@ -14,6 +14,19 @@ describe Elasticsearch::API::Response::ExplainResponse do
     it "returns summary" do
       expect(subject).not_to be_empty
     end
+
+    context "with block" do
+      subject do
+        described_class.render_in_line(fake_response, colorize: false) do |tree|
+          tree.children = tree.children[0..1]
+          tree
+        end
+      end
+
+      it "changes the tree before rendering" do
+        expect(subject).to eq("0.05 = (0.11(score) x 0.5(coord(1/2)))")
+      end
+    end
   end
 
   describe '.render' do


### PR DESCRIPTION
:bonus:
Now `render` method takes block arguments: it allows the external problem modify the trees before rendering 
